### PR TITLE
Restore Cygwin build on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,7 @@ init:
 
 install:
   - 'appveyor DownloadFile http://cygwin.com/setup-%CYG_ARCH%.exe -FileName setup.exe'
-  - 'setup.exe -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P make -P git -P gcc-core -P gcc-g++ -P ocaml -P ocaml-camlp4 -P ocaml-compiler-libs -P libncurses-devel -P unzip >NUL'
-  - 'setup.exe -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P libmpfr-devel -P patch -P flexdll -P libglpk-devel >NUL'
+  - 'setup.exe -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P make,git,gcc-core,gcc-g++,ocaml,ocaml-camlp4,ocaml-compiler-libs,libncurses-devel,unzip,libmpfr-devel,patch,flexdll,libglpk-devel >NUL'
   - '%CYG_ROOT%/bin/bash -lc "cygcheck -dc cygwin gcc-core"'
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ init:
 
 install:
   - 'appveyor DownloadFile http://cygwin.com/setup-%CYG_ARCH%.exe -FileName setup.exe'
-  - 'setup.exe -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P make,git,gcc-core,gcc-g++,ocaml,ocaml-camlp4,ocaml-compiler-libs,libncurses-devel,unzip,libmpfr-devel,patch,flexdll,libglpk-devel >NUL'
+  - 'setup.exe -gqnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P make,git,gcc-core,gcc-g++,ocaml,ocaml-camlp4,ocaml-compiler-libs,libncurses-devel,unzip,libmpfr-devel,patch,flexdll,libglpk-devel >NUL'
   - '%CYG_ROOT%/bin/bash -lc "cygcheck -dc cygwin gcc-core"'
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ install:
   - 'appveyor DownloadFile http://cygwin.com/setup-%CYG_ARCH%.exe -FileName setup.exe'
   - 'setup.exe -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P make -P git -P gcc-core -P gcc-g++ -P ocaml -P ocaml-camlp4 -P ocaml-compiler-libs -P libncurses-devel -P unzip >NUL'
   - 'setup.exe -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P libmpfr-devel -P patch -P flexdll -P libglpk-devel >NUL'
-  - '%CYG_ROOT%/bin/bash -lc "cygcheck -dc cygwin"'
+  - '%CYG_ROOT%/bin/bash -lc "cygcheck -dc cygwin gcc-core"'
 
 build_script:
   - '%CYG_ROOT%/bin/bash -lc "cd \"$OLDPWD\" && env DJDIR="workaround" ./configure && make lib-ext && make && make install"'


### PR DESCRIPTION
Cygwin recently switched to GCC 6 and the build appears to need something either from Cygwin 2.8 or 2.9 - so the existing packages on the AppVeyor at least for now need to be updated too. This involves adding `-g` to the setup line.